### PR TITLE
Fix spelling of 'address'

### DIFF
--- a/lib/refactoring_a_test/customer.rb
+++ b/lib/refactoring_a_test/customer.rb
@@ -1,1 +1,1 @@
-Customer = Struct.new(:number, :name, :last_name, :percent_discount, :billing_address, :shipping_adress)
+Customer = Struct.new(:number, :name, :last_name, :percent_discount, :billing_address, :shipping_address)

--- a/spec/refactoring_a_test_spec.rb
+++ b/spec/refactoring_a_test_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RefactoringATest do
         last_name: "Doe",
         percent_discount: BigDecimal("30"),
         billing_address: billing_address,
-        shipping_adress: shipping_address
+        shipping_address: shipping_address
       )
       product = FactoryBot.create(:product, number: 88, code: "SomeWidget", unit_price: BigDecimal("19.99"))
       invoice = FactoryBot.create(:invoice, customer: customer)


### PR DESCRIPTION
Fix the spelling of 'address' in the test as well as the Customer attribute. 